### PR TITLE
add a splitter for state inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 
 3_visualize/out/*
 .remake/*
+1_fetch/tmp/*
+!1_fetch/tmp/state_splits.yml
+

--- a/123_state_tasks.R
+++ b/123_state_tasks.R
@@ -1,5 +1,6 @@
 do_state_tasks <- function(oldest_active_sites, ...) {
 
+  split_inventory(summary_file = '1_fetch/tmp/state_splits.yml', sites_info = oldest_active_sites)
   # Define task table rows
   # TODO: DEFINE A VECTOR OF TASK NAMES HERE
   task_name <- oldest_active_sites$state_cd
@@ -13,7 +14,7 @@ do_state_tasks <- function(oldest_active_sites, ...) {
     },
     # TODO: Make commands that call get_site_data()
     command = function(task_name, ...) {
-      sprintf("get_site_data(oldest_active_sites, state = I('%s'), parameter = parameter)", task_name)
+      sprintf("get_site_data(sites_info_file = '1_fetch/tmp/inventory_%s.tsv', parameter = parameter)", task_name)
     }
   )
 
@@ -40,4 +41,22 @@ do_state_tasks <- function(oldest_active_sites, ...) {
 
   # Return nothing to the parent remake file
   return()
+}
+
+split_inventory <- function(summary_file = '1_fetch/tmp/state_splits.yml', sites_info=oldest_active_sites) {
+
+  if(!dir.exists('1_fetch/tmp')) dir.create('1_fetch/tmp')
+
+  # loop over oldest_active_sites to create temp files
+  for (state in sites_info$state_cd){
+    temp_dat <- filter(sites_info, state_cd %in% state)
+    temp_filename <- file.path('1_fetch', 'tmp', sprintf('inventory_%s.tsv', state))
+    readr::write_tsv(temp_dat, path = temp_filename)
+  }
+
+  split_filenames <- file.path('1_fetch', 'tmp', sprintf('inventory_%s.tsv', sites_info$state_cd))
+  split_filenames_a <- split_filenames[order(split_filenames)]
+
+  # write summary file
+  scipiper::sc_indicate(ind_file = summary_file, data_file = split_filenames_a)
 }

--- a/123_state_tasks.yml
+++ b/123_state_tasks.yml
@@ -25,24 +25,36 @@ targets:
       - MN_data
       - MI_data
       - IL_data
+      - IN_data
+      - IA_data
 
   # --- WI --- #
   
   WI_data:
-    command: get_site_data(oldest_active_sites, state = I('WI'), parameter = parameter)
+    command: get_site_data(sites_info_file = '1_fetch/tmp/inventory_WI.tsv', parameter = parameter)
 
   # --- MN --- #
   
   MN_data:
-    command: get_site_data(oldest_active_sites, state = I('MN'), parameter = parameter)
+    command: get_site_data(sites_info_file = '1_fetch/tmp/inventory_MN.tsv', parameter = parameter)
 
   # --- MI --- #
   
   MI_data:
-    command: get_site_data(oldest_active_sites, state = I('MI'), parameter = parameter)
+    command: get_site_data(sites_info_file = '1_fetch/tmp/inventory_MI.tsv', parameter = parameter)
 
   # --- IL --- #
   
   IL_data:
-    command: get_site_data(oldest_active_sites, state = I('IL'), parameter = parameter)
+    command: get_site_data(sites_info_file = '1_fetch/tmp/inventory_IL.tsv', parameter = parameter)
+
+  # --- IN --- #
+  
+  IN_data:
+    command: get_site_data(sites_info_file = '1_fetch/tmp/inventory_IN.tsv', parameter = parameter)
+
+  # --- IA --- #
+  
+  IA_data:
+    command: get_site_data(sites_info_file = '1_fetch/tmp/inventory_IA.tsv', parameter = parameter)
 

--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,8 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(sites_info_file, parameter) {
+  site_info <- readr::read_tsv(sites_info_file, col_types='cccddcDDi')
+
   message(sprintf('  Retrieving data for %s-%s', site_info$state_cd, site_info$site_no))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/1_fetch/tmp/state_splits.yml
+++ b/1_fetch/tmp/state_splits.yml
@@ -1,0 +1,7 @@
+1_fetch/tmp/inventory_IA.tsv: 592527f5195c54eddbedea6a57e23a10
+1_fetch/tmp/inventory_IL.tsv: 609cdc178e707d0c0a05ab1363f70517
+1_fetch/tmp/inventory_IN.tsv: 62cf86298e8ddf65ef464bbb401ab1b1
+1_fetch/tmp/inventory_MI.tsv: 4f6617513d4bb92e84f641afadae8e8d
+1_fetch/tmp/inventory_MN.tsv: a8ea5143a937c3b289239af040a4a5ae
+1_fetch/tmp/inventory_WI.tsv: d3e27869a95acc4587dc2157879438eb
+

--- a/remake.yml
+++ b/remake.yml
@@ -22,7 +22,7 @@ targets:
 
   # Configuration
   states:
-    command: c(I(c('WI','MN','MI', 'IL')))
+    command: c(I(c('WI','MN','MI', 'IL', 'IN', 'IA')))
   parameter:
     command: c(I('00060'))
 


### PR DESCRIPTION
When new states were added, the only obvious (e.g., from the build message) file that rebuilt was `3_visualize/out/site_map.png`.

Behind the scenes, `123_state_tasks.yml`, `state_splits.yml` were rebuilt, and the files `inventory_IN.tsv` and `inventory_IA.tsv` were added.