### PR TITLE
add two combiners, add leaflet map at end to use combined products

### DIFF
--- a/123_state_tasks.R
+++ b/123_state_tasks.R
@@ -43,7 +43,8 @@ do_state_tasks <- function(oldest_active_sites, ...) {
   task_plan <- create_task_plan(
     task_names = task_name,
     task_steps = list(download_step, plot_step, tally_step),
-    add_complete = FALSE)
+    add_complete = FALSE,
+    final_steps = c('tally', 'plot'))
 
   # Create the task remakefile
   create_task_makefile(
@@ -53,14 +54,22 @@ do_state_tasks <- function(oldest_active_sites, ...) {
     include = 'remake.yml',
     sources = c(...),
     packages = c('dplyr', 'dataRetrieval', 'lubridate'),
-    tickquote_combinee_objects = FALSE,
-    finalize_funs = c())
+    tickquote_combinee_objects = TRUE,
+    finalize_funs = c('combine_obs_tallies', 'summarize_timeseries_plots'),
+    final_targets = c('obs_tallies', '3_visualize/out/timeseries_plots.yml'),
+    as_promises = TRUE)
 
   # Build the tasks
-  scmake('123_state_tasks', remake_file='123_state_tasks.yml')
+  obs_tallies <- scmake('obs_tallies_promise', remake_file='123_state_tasks.yml')
+  scmake('timeseries_plots.yml_promise', remake_file='123_state_tasks.yml')
 
-  # Return nothing to the parent remake file
-  return()
+  timeseries_plots_info <- yaml::yaml.load_file('3_visualize/out/timeseries_plots.yml') %>%
+    tibble::enframe(name = 'filename', value = 'hash') %>%
+    mutate(hash = purrr::map_chr(hash, `[[`, 1))
+
+  # Return combined obs_tallies
+  # Return the combiner targets to the parent remake file
+  return(list(obs_tallies=obs_tallies, timeseries_plots_info=timeseries_plots_info))
 }
 
 split_inventory <- function(summary_file = '1_fetch/tmp/state_splits.yml', sites_info=oldest_active_sites) {
@@ -79,4 +88,21 @@ split_inventory <- function(summary_file = '1_fetch/tmp/state_splits.yml', sites
 
   # write summary file
   scipiper::sc_indicate(ind_file = summary_file, data_file = split_filenames_a)
+}
+
+combine_obs_tallies <- function(...) {
+  # filter to just those arguments that are tibbles (because the only step
+  # outputs that are tibbles are the tallies)
+  dots <- list(...)
+  tally_dots <- dots[purrr::map_lgl(dots, is_tibble)]
+  out <- bind_rows(tally_dots)
+  return(out)
+}
+
+summarize_timeseries_plots <- function(ind_file, ...) {
+  # filter to just those arguments that are character strings (because the only
+  # step outputs that are characters are the plot filenames)
+  dots <- list(...)
+  plot_dots <- dots[purrr::map_lgl(dots, is.character)]
+  do.call(combine_to_ind, c(list(ind_file), plot_dots))
 }

--- a/123_state_tasks.yml
+++ b/123_state_tasks.yml
@@ -1,7 +1,6 @@
 # Do not edit - automatically generated
 # from the task_makefile.mustache template
 # by create_task_makefile() via do_state_tasks()
-# using scipiper package version 0.0.18
 
 target_default: 123_state_tasks
 
@@ -17,6 +16,7 @@ sources:
   - 1_fetch/src/get_site_data.R
   - 3_visualize/src/plot_site_data.R
   - 2_process/src/tally_site_obs.R
+  - 123_state_tasks.R
 
 file_extensions:
   - "ind"
@@ -24,24 +24,8 @@ file_extensions:
 targets:
   123_state_tasks:
     depends:
-      - WI_data
-      - '3_visualize/out/timeseries_WI.png'
-      - WI_tally
-      - MN_data
-      - '3_visualize/out/timeseries_MN.png'
-      - MN_tally
-      - MI_data
-      - '3_visualize/out/timeseries_MI.png'
-      - MI_tally
-      - IL_data
-      - '3_visualize/out/timeseries_IL.png'
-      - IL_tally
-      - IN_data
-      - '3_visualize/out/timeseries_IN.png'
-      - IN_tally
-      - IA_data
-      - '3_visualize/out/timeseries_IA.png'
-      - IA_tally
+      - obs_tallies_promise
+      - timeseries_plots.yml_promise
 
   # --- WI --- #
   
@@ -109,3 +93,50 @@ targets:
   IA_tally:
     command: tally_site_obs(site_data = IA_data)
 
+  # --- OH --- #
+  
+  OH_data:
+    command: get_site_data(sites_info_file = '1_fetch/tmp/inventory_OH.tsv', parameter = parameter)
+
+  3_visualize/out/timeseries_OH.png:
+    command: plot_site_data(out_file = target_name, site_data = OH_data, parameter = parameter)
+
+  OH_tally:
+    command: tally_site_obs(site_data = OH_data)
+
+  # --- Overall job --- #
+
+  obs_tallies_promise:
+    command: combine_obs_tallies(
+      `WI_tally`,
+      '3_visualize/out/timeseries_WI.png',
+      `MN_tally`,
+      '3_visualize/out/timeseries_MN.png',
+      `MI_tally`,
+      '3_visualize/out/timeseries_MI.png',
+      `IL_tally`,
+      '3_visualize/out/timeseries_IL.png',
+      `IN_tally`,
+      '3_visualize/out/timeseries_IN.png',
+      `IA_tally`,
+      '3_visualize/out/timeseries_IA.png',
+      `OH_tally`,
+      '3_visualize/out/timeseries_OH.png')
+    
+  timeseries_plots.yml_promise:
+    command: summarize_timeseries_plots(I('3_visualize/out/timeseries_plots.yml'),
+      `WI_tally`,
+      '3_visualize/out/timeseries_WI.png',
+      `MN_tally`,
+      '3_visualize/out/timeseries_MN.png',
+      `MI_tally`,
+      '3_visualize/out/timeseries_MI.png',
+      `IL_tally`,
+      '3_visualize/out/timeseries_IL.png',
+      `IN_tally`,
+      '3_visualize/out/timeseries_IN.png',
+      `IA_tally`,
+      '3_visualize/out/timeseries_IA.png',
+      `OH_tally`,
+      '3_visualize/out/timeseries_OH.png')
+    

--- a/1_fetch/tmp/state_splits.yml
+++ b/1_fetch/tmp/state_splits.yml
@@ -1,7 +1,8 @@
-1_fetch/tmp/inventory_IA.tsv: 592527f5195c54eddbedea6a57e23a10
-1_fetch/tmp/inventory_IL.tsv: 609cdc178e707d0c0a05ab1363f70517
-1_fetch/tmp/inventory_IN.tsv: 62cf86298e8ddf65ef464bbb401ab1b1
-1_fetch/tmp/inventory_MI.tsv: 4f6617513d4bb92e84f641afadae8e8d
-1_fetch/tmp/inventory_MN.tsv: a8ea5143a937c3b289239af040a4a5ae
-1_fetch/tmp/inventory_WI.tsv: d3e27869a95acc4587dc2157879438eb
+1_fetch/tmp/inventory_IA.tsv: 9bea6d5091b2699f7b00cdc073369dcd
+1_fetch/tmp/inventory_IL.tsv: 3b5d480a0da80d5427507fb763a08b8f
+1_fetch/tmp/inventory_IN.tsv: f0658aff0a1aa3e410be0662c256a00b
+1_fetch/tmp/inventory_MI.tsv: 7c59d50783c4f944cebe213f816ed5fc
+1_fetch/tmp/inventory_MN.tsv: cd64efec04834d223ad9d196924b0caf
+1_fetch/tmp/inventory_OH.tsv: dc2a4066daa7131fab41e3c781d854c2
+1_fetch/tmp/inventory_WI.tsv: f25d0e760f717f8a437698bca0a9878d
 

--- a/remake.yml
+++ b/remake.yml
@@ -7,22 +7,29 @@ packages:
   - rnaturalearth
   - cowplot
   - scipiper
+  - leaflet
+  - leafpop
+  - htmlwidgets
 
 sources:
   - 1_fetch/src/find_oldest_sites.R
   - 3_visualize/src/map_sites.R
   - 1_fetch/src/get_site_data.R
   - 123_state_tasks.R
+  - 3_visualize/src/plot_data_coverage.R
+  - 3_visualize/src/map_timeseries.R
 
 targets:
   main:
     depends:
-      - state_tasks
       - 3_visualize/out/site_map.png
+      - 3_visualize/out/data_coverage.png
+      - 3_visualize/out/timeseries_map.html
+
 
   # Configuration
   states:
-    command: c(I(c('WI','MN','MI', 'IL', 'IN', 'IA')))
+    command: c(I(c('WI','MN','MI', 'IL', 'IN', 'IA', 'OH')))
   parameter:
     command: c(I('00060'))
 
@@ -31,14 +38,30 @@ targets:
     command: find_oldest_sites(states, parameter)
 
   # TODO: PULL SITE DATA HERE
-  state_tasks:
+  state_combiners:
     command: do_state_tasks(
       oldest_active_sites,
       '1_fetch/src/get_site_data.R',
       '3_visualize/src/plot_site_data.R',
-      '2_process/src/tally_site_obs.R')
+      '2_process/src/tally_site_obs.R',
+      '123_state_tasks.R')
     depends: parameter
+
+  obs_tallies:
+    command: pluck(state_combiners, target_name)
+
+  timeseries_plots_info:
+    command: pluck(state_combiners, target_name)
 
   # Map oldest sites
   3_visualize/out/site_map.png:
     command: map_sites(oldest_active_sites, target_name)
+
+  # show data availability by year-site
+  3_visualize/out/data_coverage.png:
+    command: plot_data_coverage(obs_tallies, target_name)
+
+  # interactive map of sites
+  3_visualize/out/timeseries_map.html:
+    command: map_timeseries(plot_info = timeseries_plots_info, site_info = oldest_active_sites, target_name)
+


### PR DESCRIPTION
This was fun! This provided a really useful template for me to look back on when I'm creating new task tables. Already implemented a [new one](https://github.com/limnoliver/2wp-temp-observations/blob/pipeline_cleanup/1_wqp_pull.yml#L46-L53) in the 2wp-temp-observations pipeline, and leaned on these examples heavily. 

Here's a zoomed-in look at the new state I added (OH).

![image](https://user-images.githubusercontent.com/15788176/88437894-17d44b00-cdcd-11ea-8371-e3cd0c1074b7.png)
